### PR TITLE
[R] deprecate watchlist warning

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -454,7 +454,8 @@ depr_par_lut <- matrix(c(
   'plot.height', 'plot_height',
   'plot.width', 'plot_width',
   'n_first_tree', 'trees',
-  'dummy', 'DUMMY'
+  'dummy', 'DUMMY',
+  'watchlist', 'evals'
 ), ncol = 2, byrow = TRUE)
 colnames(depr_par_lut) <- c('old', 'new')
 


### PR DESCRIPTION
Regarding the renaming of `watchlist` to `evals` in `xgb.train()` as per #10032 , we might consider raising a warning.

Often, the main training logic in R is to use `xgb.train()` with early stopping on the watchlist. By renaming watchlist, such cases will accidently use the training data for early stopping, which means that the model does not stop training until the maximum possible number of rounds is reached.

To avoid too many silent mistakes, we can raise the warning.


